### PR TITLE
vanderhoof courthouse pm10 had 1 hour for 1 instrument, all daily avg's NA's. now compiles

### DIFF
--- a/_02-compileBooks.R
+++ b/_02-compileBooks.R
@@ -18,8 +18,8 @@ rootNoBugs<-root[!(1:length(root) %in% bugs)]
 
 purrr::walk(
   #compile reports for stations without bugs
-  rootNoBugs[1:length(rootNoBugs)], #%>% utils::View(.),
-  # root[116],
+  # rootNoBugs[1:length(rootNoBugs)], #%>% utils::View(.),
+  root[110],
             function(r){
               
               # testing

--- a/statSummaryFcns/pm10StatsFcn.R
+++ b/statSummaryFcns/pm10StatsFcn.R
@@ -127,6 +127,26 @@ pm10StatsFcn<-function(data,pm10column,dateColumn){
                    na.rm = TRUE))
   
   #calculate daily percentiles over the year:
+  
+  if(sum(is.na(dt$value))==nrow(dt)){
+    
+    dp<-dt %>%
+      dplyr::group_by(date=lubridate::year(date)) %>%
+      dplyr::summarise(`0%(day)`=NA_real_,
+                       `10%(day)`=NA_real_,
+                       `25%(day)`=NA_real_,
+                       `50%(day)`=NA_real_,
+                       `75%(day)`=NA_real_,
+                       `90%(day)`=NA_real_,
+                       `95%(day)`=NA_real_,
+                       `98%(day)`=NA_real_,
+                       `99%(day)`=NA_real_,
+                       `99.5%(day)`=NA_real_,
+                       `99.9%(day)`=NA_real_,
+                       `100%(day)`=NA_real_,)
+    
+  } else{
+    
   dp<-dt %>%
     dplyr::group_by(date=lubridate::year(date)) %>%
     dplyr::summarise(`0%(day)`=rcaaqs:::quantile2(value,
@@ -192,6 +212,8 @@ pm10StatsFcn<-function(data,pm10column,dateColumn){
     # ),
     `100%(day)`=max(value,
                     na.rm = TRUE))
+  
+  }
   
   #count daily exceedances of 50 ug/m3:
   


### PR DESCRIPTION
modified pm10StatsFcn so that all daily percentiles are NA's when this is the case (when all daily avg's are NA's). this doesn't happen automatically using `rcaaqs:::quantile2` - it throws an error.