### PR TITLE
tidy up

### DIFF
--- a/_04-compileBooks.R
+++ b/_04-compileBooks.R
@@ -10,7 +10,6 @@ yearToValidate<-2023
 #indices in roots that won't compile: 
 bugs<-c(20, # courtenay elementary school -> issue with wind rose
         24, # duncan college street issue with wind rose
-        47 # kelowna -> issue with wind rose
         )
 
 rootNoBugs<-root[!(1:length(root) %in% bugs)]
@@ -19,11 +18,11 @@ utils::View(rootNoBugs)
 
 purrr::walk(#root[3:length(root)],
   #compile reports for stations without bugs
-  # rootNoBugs[44:length(rootNoBugs)], #%>% utils::View(.),
+  rootNoBugs[1:length(rootNoBugs)], #%>% utils::View(.),
   
   #compile reports for specific stations: butler park, columbia gardens airport, birchbank,
   # warfield elementary and warfield haley park
-  root[47],
+  # root[47],
             function(r){
               
               # testing


### PR DESCRIPTION
`_04-compileBooks.R` modified so that all books will compile except two stations with bugs (wind duplicates at Duncan College Street and Courtenay Elementary School).