### PR TITLE
legend is at bottom now

### DIFF
--- a/plotlyFcn.R
+++ b/plotlyFcn.R
@@ -77,7 +77,8 @@ plotlyFcn<-function(data, # hourly data
                    
                
                
-                 plotly::ggplotly(p)
+                 plotly::ggplotly(p) %>%
+                   layout(legend = list(orientation = 'h',y = -0.5))
                  
                
              }#STATION LOOP


### PR DESCRIPTION
solution found here to move ggplotly legend from right to bottom:
https://stackoverflow.com/questions/55495512/ggplot-legend-options-will-not-be-adopted-in-ggplotly-in-shiny?rq=3